### PR TITLE
Add security for production apps

### DIFF
--- a/controllers/service.js
+++ b/controllers/service.js
@@ -4,9 +4,8 @@ const { appSalt1, appSalt2 } = require("./../vars")
 const appDb = require("./../db/apps")
 const {
   hashPassword,
-  createHexToken,
-  nowInSeconds,
   sendAccountChangesNotification,
+  generateAppKeys,
 } = require("./../utils")
 const Session = require("./../auth/session")
 
@@ -212,27 +211,6 @@ async function getAppInformation(appId) {
   const { status, data } = await appDb.findSingleApp({ id: appId })
   if (status !== "success") return null
   return data
-}
-
-/**
- * @description Generates "client" and "secret" keys
- * @param {String} email user's email
- * @param {String} appName name of the app which the keys are to be generated for
- * @param {String} callbackUrl app's callback url
- * @returns {Object}
- */
-function generateAppKeys(email, appName, callbackUrl) {
-  if (!email || !appName || !callbackUrl) throw new Error("Parameters missing")
-
-  const client = createHexToken(
-      `${email}${appName}${callbackUrl}${nowInSeconds()}`,
-      appSalt2
-    ),
-    secret = createHexToken(
-      `${email}${appName}${callbackUrl}${nowInSeconds()}`,
-      appSalt1
-    )
-  return { client, secret }
 }
 
 /**

--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -65,7 +65,7 @@ async function appAuthentication(req, res, next) {
 
   if (insecureProductionAppAccess(appInfo, req)) {
     let { client: newClient, secret: newSecret } = generateAppKeys(
-      email,
+      appInfo.owner.email,
       appInfo.name,
       appInfo.callbackUrl
     )
@@ -78,8 +78,8 @@ async function appAuthentication(req, res, next) {
 
     if (appUpdateStatus === "success")
       await sendAccountChangesNotification(
-        account.firstName,
-        account.email,
+        appInfo.owner.firstName,
+        appInfo.owner.email,
         appInfo.name
       )
 

--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -5,6 +5,7 @@ const {
   generateAppKeys,
   insecureProductionAppAccess,
   hashPassword,
+  sendAccountChangesNotification,
 } = require("./../utils")
 const { appSalt1, mlauthServiceClient } = require("./../vars")
 const Session = require("./../auth/session")

--- a/utils/index.js
+++ b/utils/index.js
@@ -80,6 +80,16 @@ async function sendAccountChangesNotification(
 }
 
 /**
+ * @description Checks if a production app is being insecurely accessed
+ * @param {Object} app
+ * @param {Request} req
+ * @returns {Boolean}
+ * */
+function insecureProductionAppAccess(app, req) {
+  return app.production && !req.secure
+}
+
+/**
  * @description Generates "client" and "secret" keys
  * @param {String} email user's email
  * @param {String} appName name of the app which the keys are to be generated for
@@ -111,4 +121,5 @@ module.exports = {
   getMissingParameters,
   sendAccountChangesNotification,
   generateAppKeys,
+  insecureProductionAppAccess,
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -79,6 +79,27 @@ async function sendAccountChangesNotification(
   return new Mail().notifyOnAccountChanges({ firstName, email }, appName)
 }
 
+/**
+ * @description Generates "client" and "secret" keys
+ * @param {String} email user's email
+ * @param {String} appName name of the app which the keys are to be generated for
+ * @param {String} callbackUrl app's callback url
+ * @returns {Object}
+ */
+function generateAppKeys(email, appName, callbackUrl) {
+  if (!email || !appName || !callbackUrl) throw new Error("Parameters missing")
+
+  const client = createHexToken(
+      `${email}${appName}${callbackUrl}${nowInSeconds()}`,
+      appSalt2
+    ),
+    secret = createHexToken(
+      `${email}${appName}${callbackUrl}${nowInSeconds()}`,
+      appSalt1
+    )
+  return { client, secret }
+}
+
 module.exports = {
   UnauthorizedException,
   BadRequestException,
@@ -89,4 +110,5 @@ module.exports = {
   nowInSeconds,
   getMissingParameters,
   sendAccountChangesNotification,
+  generateAppKeys,
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,6 @@
 const crypto = require("crypto")
 const Mail = require("./../mail")
+const { appSalt1, appSalt2 } = require("./../vars")
 
 function UnauthorizedException(reason) {
   this.status = 401


### PR DESCRIPTION
- Limit production apps to secure requests only
- Change keys when production apps keys are used to access mlAuth insecurely

close #8 